### PR TITLE
Fix FOV access in Shepp Logan dataset

### DIFF
--- a/generate_cartesian_shepp_logan_dataset.py
+++ b/generate_cartesian_shepp_logan_dataset.py
@@ -47,11 +47,11 @@ def create(filename='testdata.h5', matrix_size=256, coils=8, oversampling=2, rep
     encoding.trajectory = ismrmrd.xsd.trajectoryType('cartesian')
 
     # encoded and recon spaces
-    efov = ismrmrd.xsd.fieldOfViewMmType()
+    efov = ismrmrd.xsd.fieldOfViewMm()
     efov.x = oversampling*256
     efov.y = 256
     efov.z = 5
-    rfov = ismrmrd.xsd.fieldOfViewMmType()
+    rfov = ismrmrd.xsd.fieldOfViewMm()
     rfov.x = 256
     rfov.y = 256
     rfov.z = 5


### PR DESCRIPTION
Encountered this when generating the phantom data in the Docker container. Looks like the schema changed [in this commit](https://github.com/ismrmrd/ismrmrd-python/commit/8c2e93fef7b130e5d397cd83cf72daac2d5cf465) to ismrmrd-python.