### PR TITLE
Update generate_cartesian_shepp_logan_dataset.py

### DIFF
--- a/generate_cartesian_shepp_logan_dataset.py
+++ b/generate_cartesian_shepp_logan_dataset.py
@@ -50,11 +50,11 @@ def create(filename='testdata.h5', matrix_size=256, coils=8, oversampling=2, rep
     encoding.trajectory = ismrmrd.xsd.trajectoryType('cartesian')
 
     # encoded and recon spaces
-    efov = ismrmrd.xsd.fieldOfViewMmType()
+    efov = ismrmrd.xsd.fieldOfViewMm()
     efov.x = oversampling*256
     efov.y = 256
     efov.z = 5
-    rfov = ismrmrd.xsd.fieldOfViewMmType()
+    rfov = ismrmrd.xsd.fieldOfViewMm()
     rfov.x = 256
     rfov.y = 256
     rfov.z = 5
@@ -109,7 +109,27 @@ def create(filename='testdata.h5', matrix_size=256, coils=8, oversampling=2, rep
     
     encoding.encodingLimits = limits
     header.encoding.append(encoding)
-
+    
+    # User Parameters
+    user = ismrmrd.xsd.userParametersType()
+    userParameterLong = ismrmrd.xsd.userParameterLongType()
+    userParameterLong.name = 'TestLong'
+    userParameterLong.value = '42'
+    user.userParameterLong.append(userParameterLong)
+    userParameterDouble = ismrmrd.xsd.userParameterDoubleType()
+    userParameterDouble.name = 'TestDouble'
+    userParameterDouble.value = '3.14159'
+    user.userParameterDouble.append(userParameterDouble)
+    userParameterString = ismrmrd.xsd.userParameterStringType()
+    userParameterString.name = 'TestString'
+    userParameterString.value = 'This is a test'
+    user.userParameterString.append(userParameterString)
+    userParameterBase64 = ismrmrd.xsd.userParameterBase64Type()
+    userParameterBase64.name = 'TestBase64'
+    userParameterBase64.value = 'QWxsIHlvdXIgYmFzZSBhcmUgYmVsb25nIHRvIHVz'
+    user.userParameterBase64.append(userParameterBase64)
+    header.userParameters = user
+    
     dset.write_xml_header(header.toXML('utf-8'))
 
     # Synthesize the k-space data


### PR DESCRIPTION
This PR resolves both the issue in #3 and an issue where the data created by generate_cartesian_shepp_logan_dataset.py caused an error. The root cause was 79d400436aaeda0bf43fa1f6961e0b7e885c25a6 which assumes that the header has a field called userParameters, which previously did not exist in the Shepp-Logan data.