### PR TITLE
Re register siginterrupts before every socket.accept() to fix `KeyboardInterrupt`

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ import ismrmrd.xsd
 import importlib
 import os
 import json
+import signal
 
 import simplefft
 import invertcontrast
@@ -42,6 +43,9 @@ class Server:
         self.socket.listen(0)
 
         while True:
+            signal.siginterrupt(signal.SIGTERM, True)
+            signal.siginterrupt(signal.SIGINT, True)
+            
             sock, (remote_addr, remote_port) = self.socket.accept()
 
             logging.info("Accepting connection from: %s:%d", remote_addr, remote_port)


### PR DESCRIPTION
Currently (might be OS specific), interrupting the server via `Ctrl+C` to shut it down only works for the first call to `socket.accept()`, and during any subsequent calls to `accept()` just ignores interrupts. I did a lot of digging and narrowed the issue down to these:

The default behavior of most system calls as of [Python 3.8 is to retry the system call rather than interrupt it and raise an exception](https://peps.python.org/pep-0475/), which would be `KeyboardInterrupt` in our case. However, this means by default, we can't `Ctrl+C` out of `accept()` call.

The signal registration in `main.py` [should change this behavior by implicitly calling](signal.siginterrupt(signalnum, flag)) `signal.siginterrupt(signalnum, flag)`:

https://github.com/kspaceKelvin/python-ismrmrd-server/blob/369f0e3c8169ed3368fa16869737ef57176c6100/main.py#L28-L29

And it works before the first `accept()` call, as we are able to interrupt it. However, something in the connection handler seems to reset the `siginterrupt` behavior, but I could not find the issue. Instead, the simplest workaround was to set the `siginterrupt` for `SIGINT` and `SIGTERM` again before every `accept()` call to enable `Ctlr+C` again.