### PR TITLE
Fix compatibility with ismrmrd-python 1.14.2+

### DIFF
--- a/analyzeflow.py
+++ b/analyzeflow.py
@@ -116,7 +116,7 @@ def process_image(imgGroup, connection, config, mrdHeader):
         os.makedirs(debugFolder)
         logging.debug("Created folder " + debugFolder + " for debug output files")
 
-    logging.debug("Processing data with %d images of type %s", len(imgGroup), ismrmrd.get_dtype_from_data_type(imgGroup[0].data_type))
+    logging.debug("Processing data with %d images of type %s", len(imgGroup), imgGroup[0].data.dtype)
 
     # Display MetaAttributes for first image
     tmpMeta = ismrmrd.Meta.deserialize(imgGroup[0].attribute_string)

--- a/connection.py
+++ b/connection.py
@@ -372,17 +372,17 @@ class Connection:
 
         image = ismrmrd.Image(header_bytes, attribute_bytes.split(b'\x00',1)[0].decode('utf-8'))  # Strip off null teminator
 
-        logging.info("    Image is size %d x %d x %d with %d channels of type %s", image.getHead().matrix_size[0], image.getHead().matrix_size[1], image.getHead().matrix_size[2], image.channels, ismrmrd.get_dtype_from_data_type(image.data_type))
+        logging.info("    Image is size %d x %d x %d with %d channels of type %s", image.getHead().matrix_size[0], image.getHead().matrix_size[1], image.getHead().matrix_size[2], image.channels, image.data.dtype)
         def calculate_number_of_entries(nchannels, xs, ys, zs):
             return nchannels * xs * ys * zs
 
         nentries = calculate_number_of_entries(image.channels, *image.getHead().matrix_size)
-        nbytes = nentries * ismrmrd.get_dtype_from_data_type(image.data_type).itemsize
+        nbytes = nentries * image.data.dtype.itemsize
 
         logging.debug("Reading in %d bytes of image data", nbytes)
         data_bytes = self.read(nbytes)
 
-        image.data.ravel()[:] = np.frombuffer(data_bytes, dtype=ismrmrd.get_dtype_from_data_type(image.data_type))
+        image.data.ravel()[:] = np.frombuffer(data_bytes, dtype=image.data.dtype)
 
         if self.savedata is True:
             if self.dset is None:

--- a/custom/filter.py
+++ b/custom/filter.py
@@ -264,7 +264,7 @@ def process_image(imgGroup, connection, config, mrdHeader):
         os.makedirs(debugFolder)
         logging.debug("Created folder " + debugFolder + " for debug output files")
 
-    logging.debug("Processing data with %d images of type %s", len(imgGroup), ismrmrd.get_dtype_from_data_type(imgGroup[0].data_type))
+    logging.debug("Processing data with %d images of type %s", len(imgGroup), imgGroup[0].data.dtype)
 
     # Note: The MRD Image class stores data as [cha z y x]
 

--- a/invertcontrast.py
+++ b/invertcontrast.py
@@ -263,7 +263,7 @@ def process_image(imgGroup, connection, config, mrdHeader):
         os.makedirs(debugFolder)
         logging.debug("Created folder " + debugFolder + " for debug output files")
 
-    logging.debug("Processing data with %d images of type %s", len(imgGroup), ismrmrd.get_dtype_from_data_type(imgGroup[0].data_type))
+    logging.debug("Processing data with %d images of type %s", len(imgGroup), imgGroup[0].data.dtype)
 
     # Note: The MRD Image class stores data as [cha z y x]
 


### PR DESCRIPTION
The function `ismrmrd.get_dtype_from_data_type()` was removed from the public API in ismrmrd-python PR #82 (merged Sep 2025; see https://github.com/ismrmrd/ismrmrd-python/pull/82/files#diff-04c0de4787e3d596089f84c78020daeb1de70750537783101a9931f2e846a0f6L3) when wildcard imports were replaced with explicit imports to clean up the public API.

This change replaces all calls to `ismrmrd.get_dtype_from_data_type(image.data_type)` with `image.data.dtype`, which is functionally equivalent since the Image class already calls `get_dtype_from_data_type()` internally during initialization to create the data array with the correct dtype.

Changes:
- connection.py: Fixed 3 occurrences in read_image()
- invertcontrast.py: Fixed logging statement
- analyzeflow.py: Fixed logging statement
- custom/filter.py: Fixed logging statement